### PR TITLE
Fix Tests

### DIFF
--- a/.github/workflows/run-tests-L8.yml
+++ b/.github/workflows/run-tests-L8.yml
@@ -40,6 +40,10 @@ jobs:
           extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
           coverage: none
 
+      - name: Install dependencies (remove passport)
+        run: composer remove --dev laravel/passport --no-interaction --no-update
+        if: matrix.laravel == '8.*'
+
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" "nesbot/carbon:>=2.62.1" --no-interaction --no-update

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -2,8 +2,10 @@
 
 namespace Spatie\Permission;
 
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 
 class Guard
 {
@@ -71,5 +73,35 @@ class Guard
         }
 
         return $possible_guards->first() ?: $default;
+    }
+
+    /**
+     * Lookup a passport guard
+     */
+    public static function getPassportClient($guard): ?Authorizable
+    {
+        $guards = collect(config('auth.guards'))->where('driver', 'passport');
+
+        if (! $guards->count()) {
+            return null;
+        }
+
+        $authGuard = Auth::guard($guards->keys()[0]);
+
+        if (! \method_exists($authGuard, 'client')) {
+            return null;
+        }
+
+        $client = $authGuard->client();
+
+        if (! $guard || ! $client) {
+            return $client;
+        }
+
+        if (self::getNames($client)->contains($guard)) {
+            return $client;
+        }
+
+        return null;
     }
 }

--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -4,8 +4,8 @@ namespace Spatie\Permission\Middlewares;
 
 use Closure;
 use Illuminate\Support\Facades\Auth;
-use Laravel\Passport\Guards\TokenGuard;
 use Spatie\Permission\Exceptions\UnauthorizedException;
+use Spatie\Permission\Guard;
 
 class PermissionMiddleware
 {
@@ -13,19 +13,12 @@ class PermissionMiddleware
     {
         $authGuard = Auth::guard($guard);
 
+        $user = $authGuard->user();
+
         // For machine-to-machine Passport clients
-        $bearerToken = $request->bearerToken();
-        if ($bearerToken) {
-            if (! $authGuard instanceof TokenGuard && ! $guard) {
-                $authGuard = Auth::guard('api');
-            }
-
-            if (method_exists($authGuard, 'client')) {
-                $user = $authGuard->client();
-            }
+        if (! $user && $request->bearerToken()) {
+            $user = Guard::getPassportClient($guard);
         }
-
-        $user = $user ?? $authGuard->user();
 
         if (! $user) {
             throw UnauthorizedException::notLoggedIn();

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -4,8 +4,8 @@ namespace Spatie\Permission\Middlewares;
 
 use Closure;
 use Illuminate\Support\Facades\Auth;
-use Laravel\Passport\Guards\TokenGuard;
 use Spatie\Permission\Exceptions\UnauthorizedException;
+use Spatie\Permission\Guard;
 
 class RoleMiddleware
 {
@@ -13,19 +13,12 @@ class RoleMiddleware
     {
         $authGuard = Auth::guard($guard);
 
+        $user = $authGuard->user();
+
         // For machine-to-machine Passport clients
-        $bearerToken = $request->bearerToken();
-        if ($bearerToken) {
-            if (! $authGuard instanceof TokenGuard && ! $guard) {
-                $authGuard = Auth::guard('api');
-            }
-
-            if (method_exists($authGuard, 'client')) {
-                $user = $authGuard->client();
-            }
+        if (! $user && $request->bearerToken()) {
+            $user = Guard::getPassportClient($guard);
         }
-
-        $user = $user ?? $authGuard->user();
 
         if (! $user) {
             throw UnauthorizedException::notLoggedIn();

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -18,6 +18,8 @@ class PermissionMiddlewareTest extends TestCase
 {
     protected $permissionMiddleware;
 
+    protected $usePassport = true;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -75,6 +77,10 @@ class PermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_cannot_access_a_route_protected_by_the_permission_middleware_of_a_different_guard(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         // These permissions are created fresh here in reverse order of guard being applied, so they are not "found first" in the db lookup when matching
         app(Permission::class)->create(['name' => 'admin-permission2', 'guard_name' => 'web']);
         $p1 = app(Permission::class)->create(['name' => 'admin-permission2', 'guard_name' => 'api']);
@@ -125,6 +131,10 @@ class PermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_can_access_a_route_protected_by_permission_middleware_if_have_this_permission(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*'], 'api');
 
         $this->testClient->givePermissionTo('edit-posts');
@@ -156,6 +166,10 @@ class PermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_can_access_a_route_protected_by_this_permission_middleware_if_have_one_of_the_permissions(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->givePermissionTo('edit-posts');
@@ -200,6 +214,10 @@ class PermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_cannot_access_a_route_protected_by_the_permission_middleware_if_have_a_different_permission(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->givePermissionTo('edit-posts');
@@ -224,6 +242,10 @@ class PermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_cannot_access_a_route_protected_by_permission_middleware_if_have_not_permissions(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->assertEquals(
@@ -254,6 +276,10 @@ class PermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_can_access_a_route_protected_by_permission_middleware_if_has_permission_via_role(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->assertEquals(
@@ -342,6 +368,10 @@ class PermissionMiddlewareTest extends TestCase
     /** @test */
     public function client_can_not_access_permission_with_guard_admin_while_login_using_default_guard(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->givePermissionTo('edit-posts');

--- a/tests/RoleMiddlewareTest.php
+++ b/tests/RoleMiddlewareTest.php
@@ -16,6 +16,8 @@ class RoleMiddlewareTest extends TestCase
 {
     protected $roleMiddleware;
 
+    protected $usePassport = true;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -48,6 +50,10 @@ class RoleMiddlewareTest extends TestCase
     /** @test */
     public function a_client_cannot_access_a_route_protected_by_role_middleware_of_another_guard(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->assignRole('clientRole');
@@ -74,6 +80,10 @@ class RoleMiddlewareTest extends TestCase
     /** @test */
     public function a_client_can_access_a_route_protected_by_role_middleware_if_have_this_role(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->assignRole('clientRole');
@@ -105,6 +115,10 @@ class RoleMiddlewareTest extends TestCase
     /** @test */
     public function a_client_can_access_a_route_protected_by_this_role_middleware_if_have_one_of_the_roles(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->assignRole('clientRole');
@@ -149,6 +163,10 @@ class RoleMiddlewareTest extends TestCase
     /** @test */
     public function a_client_cannot_access_a_route_protected_by_the_role_middleware_if_have_a_different_role(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->assignRole(['clientRole']);
@@ -173,6 +191,10 @@ class RoleMiddlewareTest extends TestCase
     /** @test */
     public function a_client_cannot_access_a_route_protected_by_role_middleware_if_have_not_roles(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->assertEquals(
@@ -195,6 +217,10 @@ class RoleMiddlewareTest extends TestCase
     /** @test */
     public function a_client_cannot_access_a_route_protected_by_role_middleware_if_role_is_undefined(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->assertEquals(
@@ -275,6 +301,10 @@ class RoleMiddlewareTest extends TestCase
     /** @test */
     public function client_can_not_access_role_with_guard_admin_while_login_using_default_guard(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->assignRole('clientRole');

--- a/tests/RoleOrPermissionMiddlewareTest.php
+++ b/tests/RoleOrPermissionMiddlewareTest.php
@@ -17,6 +17,8 @@ class RoleOrPermissionMiddlewareTest extends TestCase
 {
     protected $roleOrPermissionMiddleware;
 
+    protected $usePassport = true;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -70,6 +72,10 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_can_access_a_route_protected_by_permission_or_role_middleware_if_has_this_permission_or_role(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->assignRole('clientRole');
@@ -148,6 +154,10 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     /** @test */
     public function a_client_can_not_access_a_route_protected_by_permission_or_role_middleware_if_have_not_this_permission_and_role(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->assertEquals(
@@ -194,6 +204,10 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     /** @test */
     public function client_can_not_access_permission_or_role_with_guard_admin_while_login_using_default_guard(): void
     {
+        if ($this->getLaravelVersion() < 9) {
+            $this->markTestSkipped('requires laravel >= 9');
+        }
+
         Passport::actingAsClient($this->testClient, ['*']);
 
         $this->testClient->assignRole('clientRole');


### PR DESCRIPTION
Try this
Passport 11 don't support laravel 8
```batch
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.2
Configuration: /laravel-permission/phpunit.xml.dist

...............................................................  63 / 525 ( 12%)
............................................................... 126 / 525 ( 24%)
............................................................... 189 / 525 ( 36%)
............................................................... 252 / 525 ( 48%)
............................................................... 315 / 525 ( 60%)
............................................................... 378 / 525 ( 72%)
............................................................... 441 / 525 ( 84%)
............................................................... 504 / 525 ( 96%)
.....................                                           525 / 525 (100%)

Time: 00:13.213, Memory: 62.00 MB

OK ( 525 tests, 1240 assertions)
```
I think that with the tests fixed you will be able to continue your work